### PR TITLE
fix paths from features to plugins

### DIFF
--- a/lib/Features/Ebay/Utils/Routes.php
+++ b/lib/Features/Ebay/Utils/Routes.php
@@ -19,7 +19,7 @@ class Routes {
 
         $host = \Routes::httpHost($options);
 
-        return $host . "/features/ebay/analyze/" .
+        return $host . "/plugins/ebay/analyze/" .
             $params[ 'project_name' ] . "/" .
             $params[ 'id_project' ] . "-" .
             $params[ 'password' ];

--- a/lib/Features/Ebay/View/Html/analyze.html
+++ b/lib/Features/Ebay/View/Html/analyze.html
@@ -178,7 +178,7 @@
 
             <ul>
                 <li tal:repeat="file reference_files" >
-                    <a tal:attributes="href string:${basepath}features/ebay/reference-files/${pid}/${project_password}/${file/index}"  tal:content="file/name"></a>
+                    <a tal:attributes="href string:${basepath}plugins/ebay/reference-files/${pid}/${project_password}/${file/index}"  tal:content="file/name"></a>
                 </li>
             </ul>
 


### PR DESCRIPTION
This makes plugin work with updated version of MateCat where `features` was replaced by `plugins`
