### PR TITLE
revert split/merge behaviour for vendors

### DIFF
--- a/lib/Features/Ebay/View/Html/analyze.html
+++ b/lib/Features/Ebay/View/Html/analyze.html
@@ -276,7 +276,7 @@
                         <span class="source_lang" tal:content="id_for_job/source">English</span> &gt; <span class="target_lang" tal:content="id_for_job/target">Italian</span>
                     </h3>
 
-                    <div class="splitbtn-cont pull-right" style="display:none;">
+                    <div class="splitbtn-cont pull-right">
                         <span class="splitmsg">Splitted in 2 parts</span>
                         <span class="label left">Split in</span>
                         <select name="" class="splitselect">
@@ -315,7 +315,7 @@
                         <a href="#" class="dosplit splitbtn disabled" title="You cannot split a job with 1 or 0 payable words.">Split</a>
 
                     </div>
-                    <div class="nosplit"><a href="#" class="domerge mergebtn" style="display:none;" >Merge all</a></div>
+                    <div class="nosplit"><a href="#" class="domerge mergebtn" >Merge all</a></div>
                     <!-- END CONTAINER SPLIT JOBS BUTTONS  -->
 
 

--- a/static/src/js/ebay-analyze.js
+++ b/static/src/js/ebay-analyze.js
@@ -37,7 +37,7 @@ $(function() {
             // reload status data from server
             reloadStatusFromServer()
                 .done(function() {
-                    loadChunkCompletionData().done( enableOrDisableSplitAndMerge )
+                    loadChunkCompletionData()
                 }) ;
         });
     }
@@ -87,7 +87,6 @@ $(function() {
 
     function chunkDataLoaded( data ) {
         drawButtonsByChunkCompletionData( data ) ;
-        enableOrDisableSplitAndMerge( data );
         return ( new $.Deferred() ).resolve( data ) ;
     }
 
@@ -99,28 +98,6 @@ $(function() {
             $('.completeProjectButton').removeClass('disabled');
         } else {
             $('.completeProjectButton').addClass('disabled');
-        }
-    }
-
-    /**
-     *
-     * @param data
-     */
-    function enableOrDisableSplitAndMerge( data ) {
-        console.log( 'enableOrDisableSplitAndMerge', data ) ;
-
-        var completed_translate = _.reject( data.project_status.translate, function( item ) {
-            return item.completed_at === null ;
-        });
-
-        if ( completed_translate.length > 0 ) {
-
-            $('.domerge').hide();
-            $('.splitbtn-cont').hide();
-        }
-        else {
-            if (data.project_status.translate.length > 1 ) $('.domerge').show();
-            else $('.splitbtn-cont').show();
         }
     }
 


### PR DESCRIPTION
This was asked by Paula Foster via email, to allow vendors to split and
merge jobs on redeliveries.